### PR TITLE
It's unnecessary to specify the character as UTF-8 in all examples

### DIFF
--- a/openid-sse-framework-1_0.html
+++ b/openid-sse-framework-1_0.html
@@ -1157,7 +1157,7 @@ Authorization: Bearer zzzz
 <div id="figstatusresp"></div>
 <pre>
 HTTP/1.1 200 OK
-Content-Type: application/json; charset=UTF-8
+Content-Type: application/json
 Cache-Control: no-store
 Pragma: no-cache
 
@@ -1182,7 +1182,7 @@ Authorization: Bearer eyJ0b2tlbiI6ImV4YW1wbGUifQo=
 <div id="figstatuswithsubjectresp"></div>
 <pre>
 HTTP/1.1 200 OK
-Content-Type: application/json; charset=UTF-8
+Content-Type: application/json
 Cache-Control: no-store
 Pragma: no-cache
 
@@ -1290,7 +1290,7 @@ Authorization: Bearer eyJ0b2tlbiI6ImV4YW1wbGUifQo=
 <div id="figupdatestatusresp"></div>
 <pre>
 HTTP/1.1 200 OK
-Content-Type: application/json; charset=UTF-8
+Content-Type: application/json
 Cache-Control: no-store
 Pragma: no-cache
 
@@ -1387,7 +1387,7 @@ Authorization: Bearer eyJ0b2tlbiI6ImV4YW1wbGUifQo=
 <div id="figreadconfigresp"></div>
 <pre>
 HTTP/1.1 200 OK
-Content-Type: application/json; charset=UTF-8
+Content-Type: application/json
 Cache-Control: no-store
 Pragma: no-cache
 
@@ -1481,7 +1481,7 @@ Authorization: Bearer eyJ0b2tlbiI6ImV4YW1wbGUifQo=
 <div id="figupdateconfigresp"></div>
 <pre>
 HTTP/1.1 200 OK
-Content-Type: application/json; charset=UTF-8
+Content-Type: application/json
 Cache-Control: no-store
 Pragma: no-cache
 
@@ -1792,7 +1792,7 @@ Pragma: no-cache
 POST /sse/verify HTTP/1.1
 Host: transmitter.example.com
 Authorization: Bearer eyJ0b2tlbiI6ImV4YW1wbGUifQo=
-Content-Type: application/json; charset=UTF-8
+Content-Type: application/json
 
 {
   "state": "VGhpcyBpcyBhbiBleGFtcGxlIHN0YXRlIHZhbHVlLgo="

--- a/openid-sse-framework-1_0.txt
+++ b/openid-sse-framework-1_0.txt
@@ -899,7 +899,7 @@ Tulshibagwale, et al.   Expires December 10, 2021              [Page 16]
 
 
    HTTP/1.1 200 OK
-   Content-Type: application/json; charset=UTF-8
+   Content-Type: application/json
    Cache-Control: no-store
    Pragma: no-cache
 
@@ -924,7 +924,7 @@ Tulshibagwale, et al.   Expires December 10, 2021              [Page 16]
    claim:
 
    HTTP/1.1 200 OK
-   Content-Type: application/json; charset=UTF-8
+   Content-Type: application/json
    Cache-Control: no-store
    Pragma: no-cache
 
@@ -1067,7 +1067,7 @@ Tulshibagwale, et al.   Expires December 10, 2021              [Page 19]
 
 
    HTTP/1.1 200 OK
-   Content-Type: application/json; charset=UTF-8
+   Content-Type: application/json
    Cache-Control: no-store
    Pragma: no-cache
 
@@ -1235,7 +1235,7 @@ Tulshibagwale, et al.   Expires December 10, 2021              [Page 22]
 
 
   HTTP/1.1 200 OK
-  Content-Type: application/json; charset=UTF-8
+  Content-Type: application/json
   Cache-Control: no-store
   Pragma: no-cache
 
@@ -1403,7 +1403,7 @@ Tulshibagwale, et al.   Expires December 10, 2021              [Page 25]
 
 
   HTTP/1.1 200 OK
-  Content-Type: application/json; charset=UTF-8
+  Content-Type: application/json
   Cache-Control: no-store
   Pragma: no-cache
 
@@ -1815,7 +1815,7 @@ Tulshibagwale, et al.   Expires December 10, 2021              [Page 32]
    POST /sse/verify HTTP/1.1
    Host: transmitter.example.com
    Authorization: Bearer eyJ0b2tlbiI6ImV4YW1wbGUifQo=
-   Content-Type: application/json; charset=UTF-8
+   Content-Type: application/json
 
    {
      "state": "VGhpcyBpcyBhbiBleGFtcGxlIHN0YXRlIHZhbHVlLgo="

--- a/openid-sse-framework-1_0.xml
+++ b/openid-sse-framework-1_0.xml
@@ -637,7 +637,7 @@ Authorization: Bearer zzzz
             <figure title="Example: Check Stream Status Response" anchor="figstatusresp">
               <artwork><![CDATA[
 HTTP/1.1 200 OK
-Content-Type: application/json; charset=UTF-8
+Content-Type: application/json
 Cache-Control: no-store
 Pragma: no-cache
 
@@ -661,7 +661,7 @@ Authorization: Bearer eyJ0b2tlbiI6ImV4YW1wbGUifQo=
             <figure title="Example: Check Stream Status Response" anchor="figstatuswithsubjectresp">
               <artwork><![CDATA[
 HTTP/1.1 200 OK
-Content-Type: application/json; charset=UTF-8
+Content-Type: application/json
 Cache-Control: no-store
 Pragma: no-cache
 
@@ -769,7 +769,7 @@ Authorization: Bearer eyJ0b2tlbiI6ImV4YW1wbGUifQo=
                 anchor="figupdatestatusresp">
                 <artwork><![CDATA[
 HTTP/1.1 200 OK
-Content-Type: application/json; charset=UTF-8
+Content-Type: application/json
 Cache-Control: no-store
 Pragma: no-cache
 
@@ -878,7 +878,7 @@ Authorization: Bearer eyJ0b2tlbiI6ImV4YW1wbGUifQo=
             <figure title="Example: Read Stream Configuration Response" anchor="figreadconfigresp">
               <artwork><![CDATA[
 HTTP/1.1 200 OK
-Content-Type: application/json; charset=UTF-8
+Content-Type: application/json
 Cache-Control: no-store
 Pragma: no-cache
 
@@ -978,7 +978,7 @@ Authorization: Bearer eyJ0b2tlbiI6ImV4YW1wbGUifQo=
               anchor="figupdateconfigresp">
               <artwork><![CDATA[
 HTTP/1.1 200 OK
-Content-Type: application/json; charset=UTF-8
+Content-Type: application/json
 Cache-Control: no-store
 Pragma: no-cache
 
@@ -1282,7 +1282,7 @@ Pragma: no-cache
 POST /sse/verify HTTP/1.1
 Host: transmitter.example.com
 Authorization: Bearer eyJ0b2tlbiI6ImV4YW1wbGUifQo=
-Content-Type: application/json; charset=UTF-8
+Content-Type: application/json
 
 {
   "state": "VGhpcyBpcyBhbiBleGFtcGxlIHN0YXRlIHZhbHVlLgo="


### PR DESCRIPTION
It's a default encoding for JSON. Furthermore, the specification tells us

> A successful response MUST use the 200 OK HTTP status code and return a JSON object using the "application/json" content.